### PR TITLE
Check for valid cursor at start of om/build.

### DIFF
--- a/src/om/core.cljs
+++ b/src/om/core.cljs
@@ -401,6 +401,7 @@
   "
   ([f cursor] (build f cursor nil))
   ([f cursor m]
+    (cursor-check cursor)
     (assert (valid? m)
       (apply str "build options contains invalid keys, only :key, "
                  ":react-key, :fn, :and opts allowed, given "


### PR DESCRIPTION
This results in a stack trace which contains the offending call to om/build.
