### PR TITLE
Prevent forceUpdate() if component not mounted

### DIFF
--- a/src/om/core.cljs
+++ b/src/om/core.cljs
@@ -751,7 +751,7 @@
                       target)
                     (let [queue (-get-queue state)]
                       (when-not (empty? queue)
-                        (doseq [c queue]
+                        (doseq [c queue :when (.isMounted c)]
                           (.forceUpdate c))
                         (-empty-queue! state)))))]
       (add-watch state watch-key


### PR DESCRIPTION
If a component unmounts between calling set-state! and the time that the
render-queue is processed, calling `forceUpdate()` on the component throws an
`Error`. We effectively want to remove the component from the render-queue when it
unmounts.

This prevents calling `forceUpdate()` when component not mounted when the
render-queue is being processed.

The other option for fixing this is to add a `(-dequeue-render! [this c])` method
to `IRenderQueue` and call from `:componentWillUnmount` function in `pure-methods`.
