### PR TITLE
transact! docstring: 'korks'

### DIFF
--- a/src/om/core.cljs
+++ b/src/om/core.cljs
@@ -717,15 +717,15 @@
   (-unlisten! state key))
 
 (defn root
-  "Take a component constructor function f, value an immutable tree of
-   associative data structures optionally an wrapped in an IAtom
-   instance, and a map of options and installs an Om/React render
-   loop.
+  "Take a component constructor function ("f"), an immutable tree of
+  associative data structures optionally wrapped in an IAtom
+  instance ("value"), and a map of options ("options"), and installs
+  an Om/React render loop.
 
    f must return an instance that at a minimum implements IRender or
    IRenderState (it may implement other React life cycle protocols). f
-   must take at least two arguments, the root cursor and the owning pure
-   node. A cursor is just the original data wrapped in an ICursor
+   must take at least two arguments, the root cursor and the backing
+   component. A cursor is just the original data wrapped in an ICursor
    instance which maintains path information. Only one root render
    loop allowed per target element. om.core/root is idempotent, if
    called again on the same target element the previous render loop


### PR DESCRIPTION
transact!:  took me a while to figure out that "korks" means "key or keys", so this is a minor correction to the docstring that makes it clear.

root: fixed grammar in the first sentence.  changed comment on the f arg to match the text of the Basic Tutorial ("backing component") instead of "pure node", since "node" is a little ambiguous.
