### PR TITLE
Update support of semantic tags

### DIFF
--- a/src/om/dom.clj
+++ b/src/om/dom.clj
@@ -65,6 +65,7 @@
     main
     map
     mark
+    marquee
     menu
     menuitem
     meta

--- a/src/om/dom.clj
+++ b/src/om/dom.clj
@@ -28,7 +28,9 @@
     datalist
     dd
     del
+    details
     dfn
+    dialog
     div
     dl
     dt
@@ -52,6 +54,7 @@
     i
     iframe
     img
+    input
     ins
     kbd
     keygen
@@ -62,7 +65,6 @@
     main
     map
     mark
-    marquee
     menu
     menuitem
     meta
@@ -72,9 +74,11 @@
     object
     ol
     optgroup
+    option
     output
     p
     param
+    picture
     pre
     progress
     q
@@ -97,6 +101,7 @@
     table
     tbody
     td
+    textarea
     tfoot
     th
     thead
@@ -109,22 +114,24 @@
     var
     video
     wbr
-    
+
     ;; svg
     circle
+    defs
     ellipse
     g
     line
+    linearGradient
+    mask
     path
+    pattern
+    polygon
     polyline
+    radialGradient
     rect
+    stop
     svg
     text
-    defs
-    linearGradient
-    polygon
-    radialGradient
-    stop
     tspan])
 
 (defn ^:private gen-react-dom-inline-fn [tag]


### PR DESCRIPTION
React supports a few additional semantic tags, so just bringing Om's tag list to parity - see http://facebook.github.io/react/docs/tags-and-attributes.html

E.g. the `<details>` tag currently doesn't work in Om, but does in React.