### PR TITLE
Remove declare of already-defined path

### DIFF
--- a/src/om/core.cljs
+++ b/src/om/core.cljs
@@ -149,7 +149,7 @@
   (-refresh-deps! [this])
   (-get-deps [this]))
 
-(declare notify* path)
+(declare notify*)
 
 (defn transact*
   ([state cursor korks f tag]


### PR DESCRIPTION
`path` is def'ed above, so doesn't need to be included in this `declare`

Resolves #337