### PR TITLE
Fix render bug causing changes to the app state not being reflected

### DIFF
--- a/src/om/core.cljs
+++ b/src/om/core.cljs
@@ -1127,6 +1127,7 @@
                                      (to-cursor (get-in value path) state path))
                                    watch-key))]
                     (when-not (-get-property state watch-key :skip-render-root)
+                      (-set-property! state watch-key :skip-render-root true)
                       (let [c (dom/render
                                 (binding [*descriptor* descriptor
                                           *instrument* instrument
@@ -1156,7 +1157,6 @@
                             (doseq [[id c] cs]
                               (when (.shouldComponentUpdate c (.-props c) (.-state c))
                                 (.forceUpdate c)))))))
-                    (-set-property! state watch-key :skip-render-root true)
                     @ret))]
       (add-watch state watch-key
         (fn [_ _ o n]


### PR DESCRIPTION
Avoid potentially nesting -set-property! calls for the :skip-render-root root
property. Makes it so that changes to the root state done while the root is
being rendered get applied immediately (in the next raf callback).