### PR TITLE
Make add/remove refs based on ref parent states and paths instead of contains? check, keep the valid refs after the to-cursor -> adapt cycle

### DIFF
--- a/src/om/core.cljs
+++ b/src/om/core.cljs
@@ -256,7 +256,7 @@
     (when-not (zero? (count refs))
       (aset cstate "__om_refs"
         (into #{}
-          (filter nil?
+          (remove nil?
             (map
               (fn [ref]
                 (let [ref-val   (value ref)
@@ -831,17 +831,25 @@
           (commit! cursor korks f)
           (-refresh-deps! cursor))))))
 
+(defn same-ref? [a b]
+  (and
+   (identical? (-state a) (-state b))
+   (= (-path a) (-path b))))
+
+(defn have-ref? [refs ref]
+  (some #(same-ref? ref %) refs))
+
 (defn add-ref-to-component! [c ref]
   (let [state (.-state c)
         refs  (or (aget state "__om_refs") #{})]
-    (when-not (contains? refs ref)
+    (when-not (have-ref? refs ref)
       (aset state "__om_refs" (conj refs ref)))))
 
 (defn remove-ref-from-component! [c ref]
   (let [state (.-state c)
         refs  (aget state "__om_refs")]
-    (when (contains? refs ref)
-      (aset state "__om_refs" (disj refs ref)))))
+    (when (have-ref? refs ref)
+      (aset state "__om_refs" (remove #(same-ref? ref %) refs)))))
 
 (defn observe
   "Given a component and a reference cursor have the component observe


### PR DESCRIPTION
This is a proposed change for #360

When a value pointed to by ref changes, `update-refs` makes the ref go through a `(adapt (to-cursor ...))` process.  First we keep the "transformed" ref instead of ignoring it.

Second, we make the "whether we have a ref" check based on parent state and path into this state instead of a `contains?` check (which for collections comes down to `identical?` check).

Since a newly added ref is never identical to a "transformed" ref, we end up with duplicate refs pointing to the same parent state and path in the component's `__om_refs` array.  Since there are always new refs in the `__om_refs` array, `refs-changed?` always tends to return `true` even when the parent state didn't change, causing `shouldComponentUpdate` to always return true when `observe` pattern is used.

After applying this patch, no duplicate refs are added to the `__om_refs` arary.  The refs stop updating when no parent state changes occur, causing the `ref-changed?` to eventually return `false` and making `shouldComponentUpdate` behave in an expected manner when `observe` is used. 