### PR TITLE
Force component updates when the local state changes

### DIFF
--- a/src/main/om/next.cljs
+++ b/src/main/om/next.cljs
@@ -308,9 +308,9 @@
   (if (satisfies? ILocalState component)
     (-set-state! component new-state)
     (gobj/set (.-state component) "omcljs$pendingState" new-state))
-  (if-let [r (get-reconciler component)]
-    (p/queue! r [component])
-    (.forceUpdate component)))
+  (when-let [r (get-reconciler component)]
+    (p/queue! r [component]))
+  (.forceUpdate component))
 
 (defn get-state
   "Get a component's local state. May provide a single key or a sequential


### PR DESCRIPTION
I noticed that `update-state!` and `set-state!` do not currently trigger a
rerender of om.next components if a reconciler is being used. My fix
may be a hack (I don't know) but I tested it and it works fine.

At the moment, `set-state!` simply queues a component update via the
reconciler if there is one. However, since the reconciler only watches
the application state and not the local state of the component, neither
`.forceUpdate` nor `update-component!` is ever called and so the
component is never rerendered.

My proposed change preserves queueing an update via the reconciler
(even though I'm not entirely sure what it's needed for) but makes sure
Om always calls `.forceUpdate` to rerender the component.