### PR TITLE
Fixed db->tree so that infinite graph loops are avoided.

### DIFF
--- a/src/test/om/next/tests.cljs
+++ b/src/test/om/next/tests.cljs
@@ -499,6 +499,15 @@
                     {:id 1, :name "Laura", :friends [{:id 0, :name "Bob"}]}
                     {:id 2, :name "Mary", :friends []}]}))))
 
+(deftest db->tree-graph-loops
+  (let [sam {:db/id 1 :person/name "Sam" :person/mate [:people/by-id 2]}
+        jenny {:db/id 2 :person/name "Jenny" :person/mate [:people/by-id 1]}
+        app-state {:widget/people [[:people/by-id 1] [:people/by-id 2]] :people/by-id {1 sam 2 jenny}}]
+    (is (= {[:people/by-id 1] {:person/name "Sam",
+                               :person/mate {:person/name "Jenny",
+                                             :person/mate [:people/by-id 1]}}}
+           (om/db->tree '[{[:people/by-id 1] [:person/name {:person/mate ...}]}] app-state app-state)))))
+
 ;; -----------------------------------------------------------------------------
 ;; Message Forwarding
 


### PR DESCRIPTION
Fixes #495

I think this is correct. I'm tracking idents seen as I recursively descent, and I'm tracking which ident is seen by the keyword used at the recursion. This might be overkill (I was originally just using a set, and that works for my tests but it seems like it might be possible to mis-identify a loop if you don't track which ref was crossed at each recursion point).

I also did *not* embed the reference at loop detection: it caused other things to break when I did that because the final tree isn't supposed to have idents in it anymore. Instead, the algorithm puts the looped object in, and stops.