### PR TITLE
OM-521: om.dom is not consistent with React's supported attributes

### DIFF
--- a/src/main/om/dom.clj
+++ b/src/main/om/dom.clj
@@ -28,7 +28,9 @@
     datalist
     dd
     del
+    details
     dfn
+    dialog
     div
     dl
     dt
@@ -62,7 +64,6 @@
     main
     map
     mark
-    marquee
     menu
     menuitem
     meta
@@ -75,6 +76,7 @@
     output
     p
     param
+    picture
     pre
     progress
     q
@@ -108,13 +110,16 @@
     var
     video
     wbr
-    
+
     ;; svg
     circle
+    clipPath
     ellipse
     g
     line
+    mask
     path
+    pattern
     polyline
     rect
     svg


### PR DESCRIPTION
This PR solves #521.

besides adding missing tags, the `marquee` tag is not supported by React so it was removed. In my tests with `om.dom`, using `dom/marquee` produced the following error: `Uncaught TypeError: React.DOM.marquee is not a function`