### PR TITLE
Fixed db->tree on recursive queries against vectors

### DIFF
--- a/src/main/om/next.cljs
+++ b/src/main/om/next.cljs
@@ -1207,7 +1207,7 @@
                                    (and (ident? v) (union? join)) (get sel (first v))
                                    :else sel)
                      graph-loop? (and recurse? (contains? (set (get idents-seen key)) v))
-                     idents-seen (if recurse?
+                     idents-seen (if (and (ident? v) recurse?)
                                    (-> idents-seen
                                      (update-in [key] (fnil conj #{}) v)
                                      (assoc-in [:last-ident key] v)) idents-seen)]


### PR DESCRIPTION
My detection of idents seen was accidentally grabbing vectors of idents instead of singles (the loop near the top of db->tree handles the former). Added tests with sample data from @Jannis and verified the fix corrects the issue.

This PR also includes the fix to the `process-roots` tests.

 Fixes #529