### PR TITLE
OM-531: Include keys in query results even if :value is nil

### DIFF
--- a/src/main/om/next/impl/parser.cljc
+++ b/src/main/om/next/impl/parser.cljc
@@ -213,7 +213,7 @@
                              (assert (or (nil? value) (map? value))
                                (str dispatch-key " mutation :value must be nil or a map with structure {:keys [...]}")))
                            (cond-> ret
-                             (not (nil? value)) (assoc key value)
+                             (contains? res :value) (assoc key value)
                              @mut-ret (assoc-in [key :result] @mut-ret)
                              @error (assoc key {:om.next/error @error}))))))))]
          (cond-> (reduce step (if (nil? target) {} []) query)

--- a/src/test/om/next/tests.cljs
+++ b/src/test/om/next/tests.cljs
@@ -213,6 +213,10 @@
     {:value v}
     {:remote true}))
 
+(defmethod read :nil/allowed
+  [{:keys [state]} k params]
+  {:value (get state k)})
+
 (defmethod read :woz/noz
   [{:keys [state]} k params]
   (if-let [v (get @state k)]
@@ -248,6 +252,10 @@
     (is (= (p {} [:baz/woz] :remote) [:baz/woz]))
     (is (= (p {:state st} [:foo/bar] :remote) []))
     (is (= (p {:state st} [:foo/bar :baz/woz] :remote) [:baz/woz]))))
+
+(deftest test-parsing-nil-value
+  (let [st (atom {:nil/allowed nil})]
+    (is (= (p {:state st} [:nil/allowed]) {:nil/allowed nil}))))
 
 (deftest test-value-and-remote
   (let [st (atom {:woz/noz 1})]


### PR DESCRIPTION
Some applications may want to return `{:value nil}` from read to indicate that something isn't set. This fixes #531.