### PR TITLE
Added test for treating union as alternate root

### DIFF
--- a/src/test/om/next/tests.cljs
+++ b/src/test/om/next/tests.cljs
@@ -877,11 +877,16 @@
       (testing "Rewrite of the same join to multiple paths"
         (is (= expected-rewritten-result (rewrite top-result)))))))
 
-(deftest test-process-roots-om526
-  (let [q [{:app/pages
-            {:page/home
-             [{:user/rooms [:id :roomname]} {:app/rooms [:id :roomname]}]}}]]
-    (is (= q (-> (om/process-roots q) :query)))))
+(deftest test-process-roots-can-promote-a-union-to-root
+  (let [server-query [(with-meta {:dashboard {:photo   [:url]
+                                              :comment [:text]}} {:query-root true})]
+        full-query [{:ui-key server-query}]
+        response {:dashboard {:url "http://images.com/x.gif"}}
+        full-response {:ui-key response}
+        {:keys [rewrite query]} (om/process-roots full-query)
+        ]
+    (is (= server-query query))
+    (is (= full-response (rewrite response)))))
 
 ;; -----------------------------------------------------------------------------
 ;; User Bugs


### PR DESCRIPTION
I was talking with @noonian on slack and realized there was one more thing to check, so I added a test to prove that union joins are treated properly when you want to promote them to root. This superseded the test labeled om-526, so I replaced that test with the new one.