### PR TITLE
OM-539: Using `?namespace/qualified` query params throws error

### DIFF
--- a/src/main/om/next.cljs
+++ b/src/main/om/next.cljs
@@ -187,10 +187,10 @@
 
 (defn- var? [x]
   (and (symbol? x)
-       (gstring/startsWith (name x) "?")))
+       (gstring/startsWith (str x) "?")))
 
 (defn- var->keyword [x]
-  (keyword (.substring (name x) 1)))
+  (keyword (.substring (str x) 1)))
 
 (defn- bind-query [query params]
   (letfn [(replace-var [node]

--- a/src/test/om/next/tests.cljs
+++ b/src/test/om/next/tests.cljs
@@ -28,6 +28,14 @@
 
 (def component-list (om/factory ComponentList))
 
+(defui ComponentWithParams
+  static om/IQueryParams
+  (params [this]
+    {:some/param 42})
+  static om/IQuery
+  (query [this]
+    '[{:some/key ?some/param} :app/title]))
+
 (deftest test-component?
   (is (om/component? (Component. {}))))
 
@@ -52,7 +60,9 @@
   (is (= (om/get-query Component)
          '[:foo/bar :baz/woz]))
   (is (= (om/get-query ComponentList)
-         '[{:components/list [:foo/bar :baz/woz]} :app/title])))
+         '[{:components/list [:foo/bar :baz/woz]} :app/title]))
+  (is (= (om/get-query ComponentWithParams)
+         '[{:some/key 42} :app/title])))
 
 (deftest test-focus-query
   (is (= (om/focus-query [:foo/bar] [])


### PR DESCRIPTION
This is a fix for #539.

- Added a test case which fails without the changes to `var?` and `var->keyword`