### PR TITLE
fixes attempts to merge joins with parameters (which are not mergeable)

### DIFF
--- a/src/main/om/next.cljs
+++ b/src/main/om/next.cljs
@@ -1273,7 +1273,7 @@
             (if (contains? (:elements-seen res) expr)
               res ; eliminate exact duplicates
               (update-in
-                (if (and (join? expr) (not (union? expr)))
+                (if (and (join? expr) (not (union? expr)) (not (list? expr)))
                   (let [jk (join-key expr)
                         jv (join-value expr)
                         q  (or (-> res :query-by-join (get jk)) [])
@@ -1281,15 +1281,15 @@
                              '...
                              (merge-joins (into [] (concat q jv))))]
                     (update-in res [:query-by-join] assoc jk nq))
-                  (update-in res [:non-joins] conj expr))
+                  (update-in res [:not-mergeable] conj expr))
                 [:elements-seen] conj expr)))]
     (let [init {:query-by-join {}
                 :elements-seen #{}
-                :non-joins []}
+                :not-mergeable []}
           res  (reduce step init query)]
       (->> (:query-by-join res)
         (mapv (fn [[jkey jsel]] {jkey jsel}))
-        (concat (:non-joins res))
+        (concat (:not-mergeable res))
         (into [])))))
 
 (defn process-roots [query]

--- a/src/test/om/next/tests.cljs
+++ b/src/test/om/next/tests.cljs
@@ -911,6 +911,25 @@
     (is (= server-query query))
     (is (= full-response (rewrite response)))))
 
+(deftest test-process-roots-preserves-query-parameters
+  (let [re-rooted-query (with-meta '({:dashboard {:photo   [:url]
+                                                  :comment [:text]}} {:x 1}) {:query-root true})
+        full-query [:a :b {:ui-key [re-rooted-query]}]
+        response {:dashboard {:url "http://images.com/x.gif"}}
+        full-response {:ui-key response}
+        {:keys [rewrite query]} (om/process-roots full-query)]
+    (is (= [:a :b re-rooted-query] query))
+    (is (= full-response (rewrite response)))))
+
+(deftest test-process-roots-preserves-parameters-2
+  (let [parameters  {:user/email "email", :user/password "password"}
+        fragment    (with-meta (list {:auth [:token ]}
+                                      parameters)
+                    {:query-root true})
+        full-query [{:current-login-q [fragment]}]
+        {:keys [rewrite query]} (om/process-roots full-query)]
+    (is (= [fragment] query))))
+
 ;; -----------------------------------------------------------------------------
 ;; User Bugs
 


### PR DESCRIPTION
This PR fixes merge-joins, which attempts to merge joins with parameters currently, and should not. Bad behavior will ensue if you promote more than one of the same kind of join with diffrent params, but that is just a user beware kind of thing...nothing much to do about it.

This, combined with the PR from @noonian brings process-roots closer to completion. I think the union part in that PR needs a test around rewrite working.