### PR TITLE
OM-552: componentWillUpdate doesn't receive correct `next-props`

### DIFF
--- a/src/main/om/next.cljs
+++ b/src/main/om/next.cljs
@@ -385,8 +385,8 @@
 (defn -next-props [next-props component]
   (unwrap
     (props*
-      (get-props next-props)
       (-> component .-props get-props)
+      (get-props next-props)
       (-> component .-state get-next-props))))
 
 (defn- merge-pending-props! [c]


### PR DESCRIPTION
This patch addresses issue #552.
It also adds a devcards example demoing the problem and its solution when the patch is applied.