### PR TITLE
Fixes om-550 mock-root problem

### DIFF
--- a/src/devcards/om/devcards/autocomplete.cljs
+++ b/src/devcards/om/devcards/autocomplete.cljs
@@ -1,8 +1,8 @@
 (ns om.devcards.autocomplete
-  (:require-macros [devcards.core :refer [defcard deftest]]
-                   [cljs.core.async.macros :refer [go]])
+  (:require-macros [cljs.core.async.macros :refer [go]])
   (:require [cljs.core.async :as async :refer [<! >! put! chan]]
             [clojure.string :as string]
+            [devcards.core :refer-macros [defcard deftest]]
             [om.next :as om :refer-macros [defui]]
             [om.dom :as dom])
   (:import [goog Uri]

--- a/src/main/om/next.clj
+++ b/src/main/om/next.clj
@@ -126,7 +126,11 @@
        (om.next/clear-prev-props! this#))
      ~'componentWillMount
      ([this#]
-       (let [indexer# (get-in (om.next/get-reconciler this#) [:config :indexer])]
+       (let [reconciler# (om.next/get-reconciler this#)
+             mock-root?# (-> (om.next/props this#) meta :om.next/mock-root?)
+             indexer#    (get-in reconciler [:config :indexer])]
+         (when mock-root?#
+           (swap! (:state reconciler#) assoc :root this#))
          (when-not (nil? indexer#)
            (om.next.protocols/index-component! indexer# this#))))
      ~'componentWillUnmount

--- a/src/main/om/next.cljs
+++ b/src/main/om/next.cljs
@@ -1408,7 +1408,7 @@
                                 *instrument* (:instrument config)]
                         (let [c (cond
                                   (not (nil? target)) ((:root-render config) (rctor data) target)
-                                  (nil? @ret) (rctor data)
+                                  (nil? @ret) (rctor (with-meta data {:om.next/mock-root? true}))
                                   :else (when-let [c' @ret]
                                           (when (mounted? c')
                                             (.forceUpdate c' data))))]


### PR DESCRIPTION
The replacement of :root in the reconciler was plugging in a raw react element, which was not compatible with get-query. I added metadata to the props on this so that when the root component mounts it can swap itself into the reconciler. 

All tests pass, and this should only affect the use of mock-root.