### PR TITLE
OM-550: drop support for mock-root

### DIFF
--- a/src/devcards/om/devcards/autocomplete.cljs
+++ b/src/devcards/om/devcards/autocomplete.cljs
@@ -1,5 +1,5 @@
 (ns om.devcards.autocomplete
-  (:require-macros [devcards.core :refer [defcard deftest]]
+  (:require-macros [devcards.core :refer [defcard deftest dom-node]]
                    [cljs.core.async.macros :refer [go]])
   (:require [cljs.core.async :as async :refer [<! >! put! chan]]
             [clojure.string :as string]
@@ -92,4 +92,6 @@
 
 (defcard test-autocomplete
   "Demonstrate simple autocompleter"
-  (om/mock-root reconciler AutoCompleter))
+  (dom-node
+    (fn [_ node]
+      (om/add-root! reconciler AutoCompleter node))))

--- a/src/devcards/om/devcards/bugs.cljs
+++ b/src/devcards/om/devcards/bugs.cljs
@@ -1,5 +1,5 @@
 (ns om.devcards.bugs
-  (:require-macros [devcards.core :refer [defcard deftest]])
+  (:require-macros [devcards.core :refer [defcard deftest dom-node]])
   (:require [cljs.test :refer-macros [is async]]
             [om.next :as om :refer-macros [defui]]
             [om.dom :as dom]))
@@ -64,7 +64,9 @@
 
 (defcard test-om-466
   "Test that Parameterized joins work"
-  (om/mock-root reconciler Dashboard))
+  (dom-node
+    (fn [_ node]
+      (om/add-root! reconciler Dashboard node))))
 
 ;; ==================
 ;; OM-552
@@ -104,7 +106,9 @@
 
 (defcard test-om-552
   "Test that componentWillUpdate receives updated next-props"
-  (om/mock-root rec Root))
+  (dom-node
+    (fn [_ node]
+      (om/add-root! rec Root node))))
 
 ;; ==================
 ;; OM-543
@@ -208,7 +212,9 @@
 
 (defcard om-543
   "Test that recursive queries in unions work"
-  (om/mock-root om-543-reconciler UnionTree))
+  (dom-node
+    (fn [_ node]
+      (om/add-root! om-543-reconciler UnionTree node))))
 
 
 (comment

--- a/src/devcards/om/devcards/core.cljs
+++ b/src/devcards/om/devcards/core.cljs
@@ -1,5 +1,5 @@
 (ns om.devcards.core
-  (:require-macros [devcards.core :refer [defcard deftest]])
+  (:require-macros [devcards.core :refer [defcard deftest dom-node]])
   (:require [cljs.test :refer-macros [is async]]
             [cljs.pprint :as pprint]
             [om.devcards.tutorials]
@@ -210,7 +210,9 @@
 
 (defcard test-counters
   "Test that we can mock a reconciler backed Om Next component into devcards"
-  (om/mock-root counters-reconciler CountersApp))
+  (dom-node
+    (fn [_ node]
+      (om/add-root! counters-reconciler CountersApp node))))
 
 (defcard test-counters-atom
   (om/app-state counters-reconciler))
@@ -297,7 +299,9 @@
 
 (defcard test-simple-recursive-syntax
   "Test that `'[:node-value {:children ...}]` syntax works."
-  (om/mock-root simple-tree-reconciler SimpleTree))
+  (dom-node
+    (fn [_ node]
+      (om/add-root! simple-tree-reconciler SimpleTree node))))
 
 ;; -----------------------------------------------------------------------------
 ;; Recursive Query Syntax with Mutations
@@ -393,7 +397,9 @@
 (defcard test-simple-recursive-syntax-with-mutation
   "Test that simple recursive syntax works with mutations and component
    local state. Cool"
-  (om/mock-root norm-tree-reconciler NormTree))
+  (dom-node
+    (fn [_ node]
+      (om/add-root! norm-tree-reconciler NormTree node))))
 
 (comment
   (pprint/pprint @(-> norm-tree-reconciler :config :indexer))
@@ -437,4 +443,6 @@
 
 (defcard test-instrument
   "Test that instrument interception works"
-  (om/mock-root instrument-reconciler RootView))
+  (dom-node
+    (fn [_ node]
+      (om/add-root! instrument-reconciler RootView node))))

--- a/src/devcards/om/devcards/shared_fn_test.cljs
+++ b/src/devcards/om/devcards/shared_fn_test.cljs
@@ -1,5 +1,5 @@
 (ns om.devcards.shared-fn-test
-  (:require-macros [devcards.core :refer [defcard deftest]])
+  (:require-macros [devcards.core :refer [defcard deftest dom-node]])
   (:require [om.next :as om :refer-macros [defui]]
             [om.dom :as dom]))
 
@@ -42,4 +42,6 @@
 
 (defcard test-om-478
   "Test that re-running shared-fn works"
-  (om/mock-root reconciler Home))
+  (dom-node
+    (fn [_ node]
+      (om/add-root! reconciler Home node))))

--- a/src/devcards/om/devcards/tutorials.cljs
+++ b/src/devcards/om/devcards/tutorials.cljs
@@ -1,5 +1,5 @@
 (ns om.devcards.tutorials
-  (:require-macros [devcards.core :refer [defcard deftest]])
+  (:require-macros [devcards.core :refer [defcard deftest dom-node]])
   (:require [cljs.test :refer-macros [is async]]
             [om.next :as om :refer-macros [defui]]
             [om.dom :as dom]))
@@ -51,7 +51,9 @@
      :parser (om/parser {:read animals-read})}))
 
 (defcard animals
-  (om/mock-root animals-reconciler AnimalsList))
+  (dom-node
+    (fn [_ node]
+      (om/add-root! animals-reconciler AnimalsList node))))
 
 ;; =============================================================================
 ;; Componentes, Identity & Normalization
@@ -163,7 +165,9 @@
      :parser (om/parser {:read cian-read :mutate cian-mutate})}))
 
 (defcard component-identity-and-normalization
-  (om/mock-root cian-reconciler RootView))
+  (dom-node
+    (fn [_ node]
+      (om/add-root! cian-reconciler RootView node))))
 
 ;; =============================================================================
 ;; Thinking With Links!
@@ -214,7 +218,9 @@
      :parser (om/parser {:read links-read})}))
 
 (defcard links
-  (om/mock-root links-reconciler LinksSomeList))
+  (dom-node
+    (fn [_ node]
+      (om/add-root! links-reconciler LinksSomeList node))))
 
 ;; =============================================================================
 ;; Queries with unions
@@ -352,4 +358,6 @@
      :parser (om/parser {:read union-read :mutate mutate})}))
 
 (defcard union
-  (om/mock-root union-reconciler Dashboard))
+  (dom-node
+    (fn [_ node]
+      (om/add-root! union-reconciler Dashboard node))))

--- a/src/main/om/next.cljs
+++ b/src/main/om/next.cljs
@@ -810,13 +810,6 @@
   [reconciler target]
   (p/remove-root! reconciler target))
 
-(defn mock-root
-  "Create an Om Next root without an actual DOM target. Useful in devcards
-   testing context."
-  [reconciler root-class]
-  {:pre [(reconciler? reconciler) (fn? root-class)]}
-  (p/add-root! reconciler root-class nil nil))
-
 ;; =============================================================================
 ;; Transactions
 


### PR DESCRIPTION
this is a fix for #550.
It removes `mock-root` and updates the devcards examples to use devcards' `dom-node` instead.

The commit message also provides an example of this.