### PR TITLE
OM-569: support React's displayName in defui

### DIFF
--- a/src/devcards/om/devcards/bugs.cljs
+++ b/src/devcards/om/devcards/bugs.cljs
@@ -216,6 +216,18 @@
     (fn [_ node]
       (om/add-root! om-543-reconciler UnionTree node))))
 
+(defui OM-569
+  Object
+  (displayName [this]
+    "Insert name")
+  (render [this]
+    (println (.. this -constructor -displayName))))
+
+(defcard om-569
+  "Render a component with `displayName`"
+  (dom-node
+    (fn [_ node]
+      (om/add-root! (om/reconciler {:state {}}) OM-569 node))))
 
 (comment
 

--- a/src/main/om/next.clj
+++ b/src/main/om/next.clj
@@ -28,7 +28,8 @@
         {:dt dt' :statics statics}))))
 
 (def lifecycle-sigs
-  '{initLocalState [this]
+  '{displayName [this]
+    initLocalState [this]
     componentWillReceiveProps [this next-props]
     componentWillUpdate [this next-props next-state]
     componentDidUpdate [this prev-props prev-state]
@@ -43,7 +44,11 @@
 
 (def reshape-map
   {:reshape
-   {'initLocalState
+   {'displayName
+    (fn [[name [this :as args] & body]]
+      `(~name ~args
+         ~@body))
+    'initLocalState
     (fn [[name [this :as args] & body]]
       `(~name ~args
          (let [ret# (do ~@body)]
@@ -172,6 +177,8 @@
                    name)
            ctor  `(defn ~(with-meta name {:jsdoc ["@constructor"]}) []
                     (this-as this#
+                      (when-not (nil? (.-displayName this#))
+                        (set! (.. this# -constructor -displayName) (.displayName this#)))
                       (.apply js/React.Component this# (js-arguments))
                       (if-not (nil? (.-initLocalState this#))
                         (set! (.-state this#) (.initLocalState this#))


### PR DESCRIPTION
adds the possibility of specifying a `displayName` function in defui that
sets React's displayName string.

adds a devcards example on how to do it