### PR TITLE
OM-572: `query-template` doesn't handle recursive unions

### DIFF
--- a/src/devcards/om/devcards/bugs.cljs
+++ b/src/devcards/om/devcards/bugs.cljs
@@ -216,6 +216,156 @@
     (fn [_ node]
       (om/add-root! om-543-reconciler UnionTree node))))
 
+(def composite-data
+  {:composite/item {:id 0
+                    :width 400
+                    :height 400
+                    :color "#428BCA"
+                    :comp/value 0
+                    :children [{:id 1
+                                :width 200
+                                :height 200
+                                :color "#9ACD32"
+                                :comp/value 0
+                                :children [{:id 3
+                                            :width 100
+                                            :height 100
+                                            :color "#CD329A"
+                                            :leaf/value 0}
+                                           {:id 4
+                                            :width 100
+                                            :height 100
+                                            :color "#32CD65"
+                                            :leaf/value 0}]}
+                               {:id 2
+                                :width 200
+                                :height 200
+                                :color "#39DBBE"
+                                :leaf/value 0}]}})
+
+(declare component)
+
+(defn display-id [this]
+  (let [{:keys [id children] :as props} (om/props this)
+        type (if children :composite :leaf)]
+    (dom/div #js {:style #js {:position "absolute"
+                              :textAlign "right"
+                              :bottom 0
+                              :zIndex 1
+                              :right 5}}
+      (dom/span nil
+        (str "id: "id " value: " (if (= :composite type) (:comp/value props) (:leaf/value props)))
+        (dom/button #js {:onClick #(om/transact! this
+                                     `[(comp/inc ~{:id id :type type})])}
+          "+")))))
+
+(defn common-div [this props & children]
+  (let [{:keys [id width height color value]} props]
+    (dom/div #js {:className (str id)
+                  :style
+                    #js {:position "relative"
+                         :float "left"
+                         :width width
+                         :height height
+                         :zIndex 2
+                         :textAlign "center"
+                         :backgroundColor color}}
+      children
+      (display-id this))))
+
+(defui Composite
+  static om/Ident
+  (ident [this {:keys [id children]}]
+    (if-not (nil? children)
+      [:composite id]
+      [:leaf id]))
+  static om/IQuery
+  (query [this]
+    '[:id :width :height :color :comp/value {:children ...}])
+  Object
+  (render [this]
+    (let [{:keys [children] :as props} (om/props this)]
+      (common-div this props (map component children)))))
+
+(def composite (om/factory Composite))
+
+(defui Leaf
+  static om/IQuery
+  (query [this]
+    '[:id :width :height :color :leaf/value])
+  Object
+  (render [this]
+    (common-div this (om/props this))))
+
+(def leaf (om/factory Leaf))
+
+(defui Component
+  static om/Ident
+  (ident [this {:keys [id children]}]
+    (if-not (nil? children)
+      [:composite id]
+      [:leaf id]))
+  static om/IQuery
+  (query [this]
+    {:leaf (om/get-query Leaf)
+     :composite (om/get-query Composite)})
+  Object
+  (render [this]
+    (let [{:keys [id] :as props} (om/props this)
+          [type id] (om/get-ident this)]
+      (({:composite composite
+         :leaf leaf} type) props))))
+
+(def component (om/factory Component))
+
+(defui CompositeApp
+  static om/IQuery
+  (query [this]
+    [{:composite/item (om/get-query Component)}])
+  Object
+  (render [this]
+    (let [{:keys [composite/item]} (om/props this)]
+      (dom/div #js {:style #js {:margin "0 auto"
+                                :display "table"}}
+        (component item)
+        (dom/div #js {:style #js {:clear "both"}})))))
+
+(defmulti composite-read om/dispatch)
+
+(defmethod composite-read :default
+  [{:keys [data] :as env} k _]
+  {:value (get data k)})
+
+(defmethod composite-read :children
+  [{:keys [parser data union-query state] :as env} k _]
+  (let [st @state
+        f #(parser (assoc env :data (get-in st %)) ((first %) union-query))]
+    {:value (into [] (map f) (:children data))}))
+
+(defmethod composite-read :composite/item
+  [{:keys [state parser query ast] :as env} k _]
+  (let [st @state
+        [type id :as entry] (get st k)
+        data (get-in st entry)
+        new-env (assoc env :data data :union-query query)]
+    {:value (parser new-env (type query))}))
+
+(defmulti composite-mutate om/dispatch)
+
+(defmethod composite-mutate 'comp/inc
+  [{:keys [state target]} k {:keys [id type]}]
+  (let [val (if (= type :composite) :comp/value :leaf/value)]
+    {:action #(swap! state update-in [type id val] inc)}))
+
+(def composite-reconciler
+  (om/reconciler {:state composite-data
+                  :parser (om/parser {:read composite-read :mutate composite-mutate})}))
+
+(defcard om-572
+  "Test that recursive queries in unions work"
+  (dom-node
+    (fn [_ node]
+      (om/add-root! composite-reconciler CompositeApp node))))
 
 (comment
 


### PR DESCRIPTION
This fixes #572.

- In the recursion case, `full-query` is only called when `pathopt` is false. Previously `full-query` didn't account for recursive queries and might return a wrong query (especially in the case of union recursion) because it would try to match the query path. Now, if `full-query` sees a recursion, it just returns the top level query.
- Added a `recursive-class-path?` helper to accomplish the above described
- Added a devcards example that show the issue being resolved