### PR TITLE
OM-592: `react-key` not working with Om.Next components

### DIFF
--- a/src/main/om/next.cljs
+++ b/src/main/om/next.cljs
@@ -458,7 +458,8 @@
 (defn react-key
   "Returns the components React key."
   [component]
-  (.. component -props -key))
+  (gobj/getValueByKeys component
+    "_reactInternalInstance" "_currentElement" "key"))
 
 (defn react-type
   "Returns the component type, regardless of whether the component has been


### PR DESCRIPTION
fixes #592

since the react key is no longer in props, we need to get it from the `_currentElement` in react's internal instance