### PR TITLE
OM-595: `index-root` blows the stack when a recursion query is not on its own component

### DIFF
--- a/src/devcards/om/devcards/bugs.cljs
+++ b/src/devcards/om/devcards/bugs.cljs
@@ -216,6 +216,44 @@
     (fn [_ node]
       (om/add-root! om-543-reconciler UnionTree node))))
 
+;; ==================
+;; OM-595
+
+(defmulti read om/dispatch)
+
+(defmethod read :item
+  [{:keys [state query parser] :as env} key _]
+  (let [st @state]
+    {:value (om/db->tree query (get st key) st)}))
+
+(def parser
+  (om/parser {:read read :mutate mutate}))
+
+(def state
+  {:item [:item/by-id 1]
+   :item/by-id {1 {:id 1
+                   :title "first"
+                   :next  [:item/by-id 2]}
+                2 {:id 2
+                   :title "second"}}})
+
+(def om-595-reconciler
+  (om/reconciler {:state  state
+                  :parser parser}))
+
+(defui OM-595-App
+  static om/IQuery
+  (query [this]
+    '[{:item [:id :title {:next ...}]}])
+  Object
+    (render [this]
+      (dom/div nil (str (om/props this)))))
+
+(defcard om-595
+  "Test that `index-root` doesn't blow the stack"
+  (dom-node
+    (fn [_ node]
+      (om/add-root! om-595-reconciler OM-595-App node))))
 
 (comment
 

--- a/src/main/om/next.cljs
+++ b/src/main/om/next.cljs
@@ -945,35 +945,33 @@
                   (when class
                     (swap! class-path->query update-in [classpath]
                       (fnil conj #{})
-                      (query-template (focus-query rootq path) path)))
-                  (when-not recursive?
-                    (cond
-                      (vector? query)
-                      (let [{props false joins true} (group-by join? query)]
-                        (when class
+                      (query-template (focus-query rootq path) path))
+                    (when-not recursive?
+                      (cond
+                        (vector? query)
+                        (let [{props false joins true} (group-by join? query)]
                           (swap! prop->classes
                             #(merge-with into %
                               (zipmap
                                 (map (comp :dispatch-key parser/expr->ast) props)
-                                (repeat #{class})))))
-                        (doseq [join joins]
-                          (let [[prop query'] (join-entry join)
-                                query'        (if (recursion? query')
-                                                query
-                                                query')]
-                            (when class
+                                (repeat #{class}))))
+                          (doseq [join joins]
+                            (let [[prop query'] (join-entry join)
+                                  query'        (if (recursion? query')
+                                                  query
+                                                  query')]
                               (swap! prop->classes
-                                #(merge-with into % {prop #{class}})))
-                            (let [class' (-> query' meta :component)]
-                              (build-index* class' query'
-                                (conj path prop) classpath)))))
+                                #(merge-with into % {prop #{class}}))
+                              (let [class' (-> query' meta :component)]
+                                (build-index* class' query'
+                                  (conj path prop) classpath)))))
 
-                      ;; Union query case
-                      (map? query)
-                      (doseq [[prop query'] query]
-                        (let [class' (-> query' meta :component)]
-                          (build-index* class' query'
-                            (conj path prop) classpath)))))))]
+                        ;; Union query case
+                        (map? query)
+                        (doseq [[prop query'] query]
+                          (let [class' (-> query' meta :component)]
+                            (build-index* class' query'
+                              (conj path prop) classpath))))))))]
         (build-index* class rootq [] [])
         (swap! indexes merge
           {:prop->classes     @prop->classes


### PR DESCRIPTION
Fixes #595 

Needed change was bringing the `(when-not recursive? ...)` code path inside the `when class` check