### PR TITLE
OM-598: `re-index!` should use the mounted instance

### DIFF
--- a/src/main/om/next.cljs
+++ b/src/main/om/next.cljs
@@ -1522,10 +1522,12 @@
     (when-let [remove (:remove @state)]
       (remove)))
 
-  (reindex! [_]
+  (reindex! [this]
     (let [root (get @state :root)]
       (when (iquery? root)
-        (p/index-root (:indexer config) root))))
+        (let [indexer (:indexer config)
+              c (first (get-in @indexer [:class->components root]))]
+          (p/index-root indexer c)))))
 
   (queue! [_ ks]
     (swap! state update-in [:queue] into ks))


### PR DESCRIPTION
fixes #598 

- adds devcards example showing the issue to be resolved when the patch is applied
- adds tests