### PR TITLE
Use ReactDOM.findDOMNode to fix deprecated warning

### DIFF
--- a/src/main/om/core.cljs
+++ b/src/main/om/core.cljs
@@ -1275,10 +1275,10 @@
   "A helper function to get at React DOM refs. Given a owning pure node
   extract the DOM ref specified by name."
   ([owner]
-   (.getDOMNode owner))
+    (js/ReactDOM.findDOMNode owner))
   ([owner name]
-   {:pre [(string? name)]}
-   (some-> (.-refs owner) (aget name) (.getDOMNode))))
+    {:pre [(string? name)]}
+    (some-> (.-refs owner) (aget name) (js/ReactDOM.findDOMNode))))
 
 (defn get-ref
   "A helper function to get at React refs. Given an owning pure node extract


### PR DESCRIPTION
Fixes the deprecation warning for `om.core/get-node` [#607](https://github.com/omcljs/om/issues/607)