### PR TITLE
[:sends-queued] -> :sends-queued

### DIFF
--- a/src/main/om/next.cljs
+++ b/src/main/om/next.cljs
@@ -1590,7 +1590,7 @@
   (schedule-sends! [_]
     (if-not (:sends-queued @state)
       (do
-        (swap! state assoc [:sends-queued] true)
+        (swap! state assoc :sends-queued true)
         true)
       false))
 


### PR DESCRIPTION
this is creating a new key under the reconciler's state instead of updating the one it should