### PR TITLE
avoid updating om.next/queries unnecessarily when unmounting

### DIFF
--- a/src/main/om/next.clj
+++ b/src/main/om/next.clj
@@ -100,7 +100,8 @@
                cfg#     (:config r#)
                st#      (:state cfg#)
                indexer# (:indexer cfg#)]
-           (when-not (nil? st#)
+           (when (and (not (nil? st#))
+                      (get-in @st# [:om.next/queries this#]))
              (swap! st# update-in [:om.next/queries] dissoc this#))
            (when-not (nil? indexer#)
              (om.next.protocols/drop-component! indexer# this#))
@@ -149,7 +150,8 @@
              cfg#     (:config r#)
              st#      (:state cfg#)
              indexer# (:indexer cfg#)]
-         (when-not (nil? st#)
+         (when (and (not (nil? st#))
+                    (get-in @st# [:om.next/queries this#]))
            (swap! st# update-in [:om.next/queries] dissoc this#))
          (when-not (nil? indexer#)
            (om.next.protocols/drop-component! indexer# this#))))}})


### PR DESCRIPTION
I have a performance-sensitive component that renders a large list of items, and it only shows a subset of items in the actual DOM to fill the view. This subset is updated as you scroll to make it appear that everything is loaded in the DOM, when it's actually not.

I noticed that when items outside the view are removed from the DOM (after scrolling), a `reconcile!` and rerender would happen. This happens because the state was being modified in `componentWillUnmount`, but we don't need to modify that state if `om.next/queries` does not have the component instance in it. This optimization avoids unnecessary rerenders, and more importantly unnecessary query execution (modifying the state triggers both).