### PR TITLE
OM-648: Regression in `index-root` for parameterized props

### DIFF
--- a/src/main/om/next.cljs
+++ b/src/main/om/next.cljs
@@ -969,8 +969,9 @@
           class             (cond-> x (component? x) type)]
       (letfn [(get-dispatch-key [prop]
                 (cond-> prop
-                  (and (ident? prop)
-                    (= (second prop) '_)) ((comp :dispatch-key parser/expr->ast))))
+                  (or (not (ident? prop))
+                      (= (second prop) '_))
+                  ((comp :dispatch-key parser/expr->ast))))
               (build-index* [class query path classpath]
                 (invariant (or (not (iquery? class))
                              (and (iquery? class)

--- a/src/test/om/next/tests.cljs
+++ b/src/test/om/next/tests.cljs
@@ -259,12 +259,24 @@
   (query [this]
     [{[:a '_] (om/get-query IdxrLinkItem)}]))
 
+(defui IdxrParamsComponent
+  static om/IQueryParams
+  (params [_]
+    {:foo ""})
+  static om/IQuery
+  (query [_]
+    '[(:some/key {:foo ?foo})]))
+
 (deftest test-indexer
   (testing "prop->classes"
     (let [idxr (om/indexer)
           idxs (p/index-root idxr ComponentList)]
       (is (= (set (keys (:prop->classes idxs)))
-            #{:app/title :components/list :foo/bar :baz/woz}))))
+            #{:app/title :components/list :foo/bar :baz/woz})))
+    (let [idxr (om/indexer)
+          idxs (p/index-root idxr IdxrParamsComponent)]
+      (is (= (set (keys (:prop->classes idxs)))
+            #{:some/key}))))
   (testing "simple recursion indexing"
     (let [idxr (om/indexer)
           idxs (p/index-root idxr IdxrTree)


### PR DESCRIPTION
`get-dispatch-key` should get the ast's dispatch key for all cases
except when it encounters an ident.