### PR TITLE
OM-556: Large values in app state slow down transactions

### DIFF
--- a/src/main/om/util.cljc
+++ b/src/main/om/util.cljc
@@ -1,0 +1,61 @@
+(ns om.util)
+
+(defn force-children [x]
+  (cond->> x
+    (seq? x) (into [] (map force-children))))
+
+(defn union?
+  #?(:cljs {:tag boolean})
+  [expr]
+  (let [expr (cond-> expr (seq? expr) first)]
+    (and (map? expr)
+      (map? (-> expr first second)))))
+
+(defn join? [x]
+  #?(:cljs {:tag boolean})
+  (let [x (if (seq? x) (first x) x)]
+    (map? x)))
+
+(defn ident?
+  "Returns true if x is an ident."
+  #?(:cljs {:tag boolean})
+  [x]
+  (and (vector? x)
+    (== 2 (count x))
+    (keyword? (nth x 0))))
+
+(defn join-entry [expr]
+  (if (seq? expr)
+    (ffirst expr)
+    (first expr)))
+
+(defn join-key [expr]
+  (cond
+    (map? expr) (ffirst expr)
+    (seq? expr) (join-key (first expr))
+    :else       expr))
+
+(defn join-value [join]
+  (second (join-entry join)))
+
+(defn unique-ident?
+  #?(:cljs {:tag boolean})
+  [x]
+  (and (ident? x) (= '_ (second x))))
+
+(defn recursion?
+  #?(:cljs {:tag boolean})
+  [x]
+  (or #?(:clj (identical? '... x)
+         :cljs (symbol-identical? '... x))
+      (number? x)))
+
+(defn mutation?
+  #?(:cljs {:tag boolean})
+  [expr]
+  (let [expr (cond-> expr (seq? expr) first)]
+    (symbol? expr)))
+
+(defn mutation-key [expr]
+  {:pre [(symbol? (first expr))]}
+  (first expr))

--- a/src/main/om/util.cljs
+++ b/src/main/om/util.cljs
@@ -1,5 +1,0 @@
-(ns om.util)
-
-(defn force-children [x]
-  (cond->> x
-    (seq? x) (into [] (map force-children))))


### PR DESCRIPTION
This patch introduces modifications to the parser's `path-meta` such
that it uses the query to walk the resulting data structure, leaving
pieces of data not present in the query as they were.

Since some utilities needed by the new `path-meta` were previously
present in the `om.next` namespace, they were moved to `om.util`.