### PR TITLE
fix `recursion?` predicate for the :clj branch

### DIFF
--- a/src/main/om/util.cljc
+++ b/src/main/om/util.cljc
@@ -46,7 +46,7 @@
 (defn recursion?
   #?(:cljs {:tag boolean})
   [x]
-  (or #?(:clj (identical? '... x)
+  (or #?(:clj (= '... x)
          :cljs (symbol-identical? '... x))
       (number? x)))
 


### PR DESCRIPTION
because `(identical? '... '...)` produces `false`, switch to using `=`