### PR TITLE
bump react, deps, align pom.xml and project.clj

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>org.clojure</groupId>
             <artifactId>clojurescript</artifactId>
-            <version>1.7.228</version>
+            <version>1.8.40</version>
             <classifier>aot</classifier>
             <scope>provided</scope>
             <exclusions>
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>org.clojure</groupId>
             <artifactId>core.async</artifactId>
-            <version>0.2.371</version>
+            <version>0.2.374</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -117,17 +117,17 @@
         <dependency>
             <groupId>com.cognitect</groupId>
             <artifactId>transit-cljs</artifactId>
-            <version>0.8.232</version>
+            <version>0.8.237</version>
         </dependency>
         <dependency>
             <groupId>cljsjs</groupId>
             <artifactId>react</artifactId>
-            <version>0.14.3-0</version>
+            <version>15.0.1-1</version>
         </dependency>
         <dependency>
             <groupId>cljsjs</groupId>
             <artifactId>react-dom</artifactId>
-            <version>0.14.3-1</version>
+            <version>15.0.1-1</version>
         </dependency>
         <dependency>
             <groupId>org.clojure</groupId>
@@ -138,7 +138,7 @@
         <dependency>
             <groupId>figwheel-sidecar</groupId>
             <artifactId>figwheel-sidecar</artifactId>
-            <version>0.5.0-2</version>
+            <version>0.5.2</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -154,7 +154,7 @@
         <dependency>
             <groupId>devcards</groupId>
             <artifactId>devcards</artifactId>
-            <version>0.2.0-8</version>
+            <version>0.2.1-6</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/project.clj
+++ b/project.clj
@@ -10,16 +10,22 @@
 
   :source-paths  ["src/main" "src/devcards" "src/test"]
 
-  :dependencies [[org.clojure/clojure "1.7.0" :scope "provided"]
-                 [org.clojure/clojurescript "1.7.170" :scope "provided"]
-                 [cljsjs/react "0.14.3-0"]
-                 [cljsjs/react-dom "0.14.3-1"]
+  :dependencies [[org.clojure/clojure "1.8.0" :scope "provided"]
+                 [org.clojure/clojurescript "1.8.40" :scope "provided"
+                  :exclusions [org.clojure/tools.reader org.clojure/data.json]]
+                 [org.clojure/tools.reader "0.10.0-alpha3" :scope "provided"]
+                 [org.clojure/data.json "0.2.6" :scope "provided"]
+                 [cljsjs/react "15.0.1-1"]
+                 [cljsjs/react-dom "15.0.1-1"]
                  [com.cognitect/transit-clj "0.8.285"]
                  [com.cognitect/transit-cljs "0.8.237"]
 
-                 [org.clojure/core.async "0.2.371" :scope "test"]
-                 [figwheel-sidecar "0.5.0" :scope "test"]
-                 [devcards "0.2.0-8" :scope "test"]]
+                 [org.clojure/core.async "0.2.374" :scope "test"
+                  :exclusions [org.clojure/tools.reader]]
+                 [figwheel-sidecar "0.5.2" :scope "test"
+                  :exclusions [org.clojure/clojurescript org.clojure/tools.reader]]
+                 [devcards "0.2.1-6" :scope "test"
+                  :exclusions [org.clojure/clojurescript]]]
 
   :plugins [[lein-cljsbuild "1.1.2"]]
 


### PR DESCRIPTION
bumps react to 15.0.1
aligns dependency versions between project.clj & pom.xml
also bumps some dependencies with "test" and "provided" scopes to their
latest versions