### PR TITLE
process-roots fails when recursive queries are outside of a query-root.

### DIFF
--- a/src/main/om/next.cljc
+++ b/src/main/om/next.cljc
@@ -2208,10 +2208,13 @@
     (if (util/join? join)
       (if (query-root? join)
         (conj result-roots [join path])
-        (mapcat
-          #(move-roots % result-roots
-            (conj path (util/join-key join)))
-          (util/join-value join)))
+        (let [joinvalue (util/join-value join)]
+          (if (vector? joinvalue)
+            (mapcat
+             #(move-roots % result-roots
+                          (conj path (util/join-key join)))
+             joinvalue)
+            result-roots)))
       result-roots)))
 
 (defn- merge-joins

--- a/src/test/om/next/tests.cljc
+++ b/src/test/om/next/tests.cljc
@@ -1821,6 +1821,13 @@
               '[{:fake/key [{:real/key ...}]}] :remote))]
     (is (= [{:real/key '...}] (:query m)))))
 
+(deftest test-process-roots-recursive-non-query-root
+  (let [p (om/parser {:read precise-read})
+        m (om/process-roots
+            (p {:state (atom {})}
+              '[{:fake/key [{:real/key ...}]} {:other/key [:other/key {:other/key ...}]}] :remote))]
+    (is (= [{:real/key '...} {:other/key [:other/key {:other/key '...}]}] (:query m)))))
+
 (deftest test-process-roots-keeps-top-rooted-keys
   (let [p (om/parser {:read precise-read :mutate precise-mutate})
         m (om/process-roots


### PR DESCRIPTION
Check for vector before mapcat in move-roots. Add test for recursive queries outside of a query root.
