### PR TITLE
Fix broken link for Time Travel post in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ these operations have no implementation complexity and little
 overhead.
 
 [See](http://swannodette.github.io/todomvc/labs/architecture-examples/om-undo/index.html)
-for [yourself](http://swannodette.github.io/2013/12/31/time-travel/).
+for [yourself](http://swannodette.github.io/2013/12/31/time-travel).
 
 ## Unique Features
 


### PR DESCRIPTION
Removed trailing slash in the link to the [Time Travel](http://swannodette.github.io/2013/12/31/time-travel) post in the README. The link didn't work for me with the slash. 