### PR TITLE
OM-717: `om.tempid/tempid` doesn't provide 0-arity function for the C…

### DIFF
--- a/src/main/om/tempid.cljc
+++ b/src/main/om/tempid.cljc
@@ -43,8 +43,11 @@
      (.write writer (str "#om/id[\"" (.id x) "\"]"))))
 
 #?(:clj
-   (defn tempid [uuid]
-     (TempId. uuid)))
+   (defn tempid
+     ([]
+      (tempid (java.util.UUID/randomUUID)))
+     ([uuid]
+      (TempId. uuid))))
 
 (defn tempid?
   #?(:cljs {:tag boolean})


### PR DESCRIPTION
…LJ branch

fixes #717 by providing a 0-arity version for `om.tempid/tempid` for compatibility with the CLJS branch