### PR TITLE
OM-729: emit `@nocollapse` jsdoc for static methods

### DIFF
--- a/src/devcards/om/devcards/autocomplete.cljs
+++ b/src/devcards/om/devcards/autocomplete.cljs
@@ -1,7 +1,7 @@
 (ns om.devcards.autocomplete
-  (:require-macros [devcards.core :refer [defcard deftest dom-node]]
-                   [cljs.core.async.macros :refer [go]])
+  (:require-macros [cljs.core.async.macros :refer [go]])
   (:require [cljs.core.async :as async :refer [<! >! put! chan]]
+            [devcards.core :refer-macros [defcard deftest dom-node]]
             [clojure.string :as string]
             [om.next :as om :refer-macros [defui]]
             [om.dom :as dom])

--- a/src/devcards/om/devcards/bugs.cljs
+++ b/src/devcards/om/devcards/bugs.cljs
@@ -1,6 +1,6 @@
 (ns om.devcards.bugs
-  (:require-macros [devcards.core :refer [defcard deftest dom-node]])
-  (:require [cljs.test :refer-macros [is async]]
+  (:require [devcards.core :refer-macros [defcard deftest dom-node]]
+            [cljs.test :refer-macros [is async]]
             [om.next :as om :refer-macros [defui]]
             [om.dom :as dom]))
 

--- a/src/devcards/om/devcards/core.cljs
+++ b/src/devcards/om/devcards/core.cljs
@@ -1,6 +1,6 @@
 (ns om.devcards.core
-  (:require-macros [devcards.core :refer [defcard deftest dom-node]])
   (:require [cljs.test :refer-macros [is async]]
+            [devcards.core :refer-macros [defcard deftest dom-node]]
             [cljs.pprint :as pprint]
             [om.devcards.utils :as utils]
             [om.devcards.tutorials]

--- a/src/devcards/om/devcards/shared_fn_test.cljs
+++ b/src/devcards/om/devcards/shared_fn_test.cljs
@@ -1,6 +1,6 @@
 (ns om.devcards.shared-fn-test
-  (:require-macros [devcards.core :refer [defcard deftest dom-node]])
-  (:require [om.next :as om :refer-macros [defui]]
+  (:require [devcards.core :refer-macros [defcard deftest dom-node]]
+            [om.next :as om :refer-macros [defui]]
             [om.dom :as dom]))
 
 (defui Home

--- a/src/devcards/om/devcards/tutorials.cljs
+++ b/src/devcards/om/devcards/tutorials.cljs
@@ -1,6 +1,6 @@
 (ns om.devcards.tutorials
-  (:require-macros [devcards.core :refer [defcard deftest dom-node]])
   (:require [cljs.test :refer-macros [is async]]
+            [devcards.core :refer-macros [defcard deftest dom-node]]
             [om.next :as om :refer-macros [defui]]
             [om.dom :as dom]))
 


### PR DESCRIPTION
fixes the elision of static methods in Om Next components by the
Closure compiler under advanced compilation.
Related Closure compiler issue:
https://github.com/google/closure-compiler/issues/1776

fix some compilation warnings, remove unused `clojure.walk` require

`devcards.core` also needs to be imported for advanced compilation to
work. It works without in Figwheel because it injects the namespace into
the build.

remove workarounds for advanced compilation in next.cljs