### PR TITLE
OM-732: db->tree treats recursion on a join as if it were on a union

### DIFF
--- a/src/main/om/next.cljs
+++ b/src/main/om/next.cljs
@@ -1405,7 +1405,6 @@
    evaluated. recurse-key is key representing the current recursive query being
    evaluted."
   [query data refs map-ident idents-seen union-expr recurse-key]
-  {:pre [(map? refs)]}
   ;; support taking ident for data param
   (let [data (loop [data data]
                (if (mappable-ident? refs data)
@@ -1474,7 +1473,10 @@
                                         (map-ident v))))
                                   v)
                     limit       (if (number? sel) sel :none)
-                    union-entry (if (util/union? join) sel union-expr)
+                    union-entry (if (util/union? join)
+                                  sel
+                                  (when recurse?
+                                    union-expr))
                     sel         (cond
                                   recurse?
                                   (if-not (nil? union-expr)
@@ -1519,8 +1521,10 @@
    application state in the default database format, return the tree where all
    ident links have been replaced with their original node values."
   ([query data refs]
+   {:pre [(map? refs)]}
    (denormalize* query data refs identity {} nil nil))
   ([query data refs map-ident]
+   {:pre [(map? refs)]}
    (denormalize* query data refs map-ident {} nil nil)))
 
 ;; =============================================================================

--- a/src/test/om/next/tests.cljs
+++ b/src/test/om/next/tests.cljs
@@ -1810,6 +1810,15 @@
     (is (= (om/db->tree [{:items [:id {:stuff ['({:name [:first]} {:param 1})]}]}] data data)
           {:items [{:id 1, :stuff [{:name {:first "John"}}]}]}))))
 
+(deftest test-om-732
+  (let [state {:curr-view [:main :view]
+               :main {:view {:curr-item [[:sub-item/by-id 2]]}}
+               :sub-item/by-id {2 {:foo :baz :sub-items [[:sub-item/by-id 4]]}
+                                4 {:foo :bar}}}]
+    (is (= (om/db->tree [{:curr-view
+                          {:main [{:curr-item [:foo {:sub-items '...}]}]}}] state state)
+          {:curr-view {:curr-item [{:foo :baz :sub-items [{:foo :bar}]}]}}))))
+
 ;; -----------------------------------------------------------------------------
 ;; Union Migration
 


### PR DESCRIPTION
also moved the pre-condition for `denormalize*` to `db->tree` so that it
isn't called on every recursive fn call