### PR TITLE
OM-734: Root re-render batching issue

### DIFF
--- a/src/devcards/om/devcards/bugs.cljs
+++ b/src/devcards/om/devcards/bugs.cljs
@@ -837,6 +837,44 @@
     (fn [_ node]
       (om/add-root! om-673-reconciler OM-673-App node))))
 
+;; ==================
+;; OM-734
+
+(def OM-734-state (atom nil))
+
+(defn handle-click! [c update-app-state?]
+  (om/update-state! c assoc :text (str "foo-" (+ 100 (rand-int 100))))
+  (when update-app-state?
+    (swap! OM-734-state update-in [:items] (fnil conj []) (rand-int 100))))
+
+(defui OM-734-Child
+  Object
+  (initLocalState [this]
+    {:text "foo"})
+  (render [this]
+    (dom/div nil
+      (dom/p nil (om/get-state this :text))
+      (dom/button #js {:onClick #(handle-click! this true)} "Local + global state")
+      (dom/button #js {:onClick #(handle-click! this false)} "Just local state"))))
+
+(def om-734-child (om/factory OM-734-Child))
+
+(defui OM-734-Root
+  Object
+  (render [this]
+    (let [items (:items (om/props this))]
+      (dom/div nil
+        (dom/ul nil
+          (map (partial dom/li nil) items))
+        (om-734-child)))))
+
+(def OM-734-reconciler (om/reconciler {:state OM-734-state}))
+
+(defcard om-734
+  (dom-node
+    (fn [_ node]
+      (om/add-root! OM-734-reconciler OM-734-Root node))))
+
 
 (comment
 


### PR DESCRIPTION
- queue the root for re-render whenever the state watch is triggered if
the root class doesn't implement IQuery
- add devcards example
- modify `schedule-render!` to always return boolean
- remove unused check in `reconcile!`