### PR TITLE
OM-753: optimize transform-reads

### DIFF
--- a/src/test/om/next/tests.cljs
+++ b/src/test/om/next/tests.cljs
@@ -2246,4 +2246,32 @@
   (let [r (om/reconciler
             {:state (atom nil)
              :parser (om/parser {:read #(do {})})})]
-    (is (= '[:foo :bar] (om/transform-reads r '[:foo :bar])))))
+    (is (= '[:foo :bar] (om/transform-reads r '[:foo :bar])))
+    (with-redefs [om/ref->components (fn [r k]
+                                       (if (= k :foo) [nil] []))
+                  om/get-query (constantly [{:foo [:bar]}])
+                  om/full-query (constantly [{:foo [:bar]}])]
+      (is (= (om/transform-reads r '[:foo :baz])
+             '[{:foo [:bar]} :baz])))
+    (with-redefs [om/ref->components (constantly [nil])
+                  om/get-query (constantly [{:foo [:bar]}])
+                  om/full-query (constantly [{:foo [:bar]}])]
+      (is (= (om/transform-reads r '[:foo :bar])
+             '[{:foo [:bar]}])))
+    (with-redefs [om/ref->components (fn [r k]
+                                       (if (= k :foo) [nil] []))
+                  om/get-query (constantly [{:foo [:bar]}])
+                  om/full-query (constantly [{:foo [:bar]}])]
+      (is (= (om/transform-reads r '[(do/it!) :foo :baz])
+             '[(do/it!) {:foo [:bar]} :baz])))
+    (with-redefs [om/ref->components (fn [r k]
+                                       (if (= k :foo) [nil] []))
+                  om/get-query (constantly [{:foo [:bar]}])
+                  om/full-query (constantly [{:foo [:bar]}])]
+      (is (= (om/transform-reads r '[(do/it!) (do/it!) :foo :baz])
+             '[(do/it!) (do/it!) {:foo [:bar]} :baz])))
+    (with-redefs [om/ref->components (constantly [nil])
+                  om/get-query (constantly [{:foo [:bar]}])
+                  om/full-query (constantly [{:foo [:bar]}])]
+      (is (= (om/transform-reads r '[(do/it!) (do/it!) :foo :bar])
+             '[(do/it!) (do/it!) {:foo [:bar]}])))))


### PR DESCRIPTION
Keeps the fix of `transform-reads` not being destructive, while also
guaranteeing that keys, whether transformed into a query or not, appear
at most once

Fixes #753 