### PR TITLE
fix autocompleter devcards example

### DIFF
--- a/src/devcards/om/devcards/autocomplete.cljs
+++ b/src/devcards/om/devcards/autocomplete.cljs
@@ -68,8 +68,10 @@
 (defn search-loop [c]
   (go
     (loop [[query cb] (<! c)]
-      (let [[_ results] (<! (jsonp (str base-url query)))]
-        (cb {:search/results results}))
+      (if-not (empty? query)
+        (let [[_ results] (<! (jsonp (str base-url query)))]
+          (cb {:search/results results}))
+        (cb {:search/results []}))
       (recur (<! c)))))
 
 (defn send-to-chan [c]


### PR DESCRIPTION
Wikipedia doesn't allow empty search queries anymore, so the remote call
will throw an error in that case. This patch changes the behavior of
`search-loop` to only perform the remote call whenever the search query
is not empty.