### PR TITLE
support dev with Boot

### DIFF
--- a/boot.properties
+++ b/boot.properties
@@ -1,0 +1,5 @@
+#http://boot-clj.com
+#Fri Sep 02 22:34:38 WEST 2016
+BOOT_CLOJURE_NAME=org.clojure/clojure
+BOOT_CLOJURE_VERSION=1.9.0-alpha10
+BOOT_VERSION=2.6.0

--- a/build.boot
+++ b/build.boot
@@ -1,0 +1,84 @@
+(set-env!
+ :source-paths    #{"src/main"}
+ :dependencies '[[org.clojure/clojure         "1.9.0-alpha10"  :scope "provided"]
+                 [org.clojure/clojurescript   "1.9.227"        :scope "provided"
+                  :classifier "aot" :exclusions [org.clojure/clojure
+                                                 org.clojure/data.json]]
+                 [org.clojure/data.json       "0.2.6"          :scope "provided"
+                  :classifier "aot"]
+                 [cljsjs/react                "15.2.1-0"]
+                 [cljsjs/react-dom            "15.2.1-0"]
+                 [com.cognitect/transit-clj   "0.8.288"]
+                 [com.cognitect/transit-cljs  "0.8.239"]
+
+                 [org.clojure/core.async      "0.2.385"        :scope "test"
+                  :exclusions [org.clojure/tools.reader]]
+                 [figwheel-sidecar            "0.5.6"          :scope "test"
+                  :exclusions [org.clojure/clojurescript
+                               org.clojure/tools.reader]]
+                 [devcards                    "0.2.1-7"        :scope "test"
+                  :exclusions [org.clojure/clojurescript]]
+                 [com.cemerick/piggieback     "0.2.1"          :scope "test"
+                  :exclusions [org.clojure/clojure
+                               org.clojure/tools.nrepl
+                               org.clojure/clojurescript]]
+                 [pandeiro/boot-http          "0.7.3"          :scope "test"]
+                 [adzerk/boot-cljs            "1.7.228-1"      :scope "test"]
+                 [adzerk/boot-cljs-repl       "0.3.3"          :scope "test"]
+                 [crisptrutski/boot-cljs-test "0.2.2-SNAPSHOT" :scope "test"]
+                 [doo                         "0.1.7"          :scope "test"
+                  :exclusions [org.clojure/clojurescript]]
+                 [adzerk/boot-reload          "0.4.12"         :scope "test"]
+                 [org.clojure/tools.nrepl     "0.2.12"         :scope "test"]
+                 [weasel                      "0.7.0"          :scope "test"
+                  :exclusions [org.clojure/clojure
+                               org.clojure/clojurescript]]])
+
+(require
+ '[adzerk.boot-cljs      :refer [cljs]]
+ '[adzerk.boot-cljs-repl :as cr :refer [cljs-repl start-repl]]
+ '[adzerk.boot-reload    :refer [reload]]
+ '[crisptrutski.boot-cljs-test :refer [test-cljs]]
+ '[pandeiro.boot-http :refer [serve]])
+
+(deftask devcards []
+  (set-env! :source-paths #(conj % "src/devcards")
+            :resource-paths #{"resources/public"})
+  (comp
+    (serve :port 3449)
+    (watch)
+    (cljs-repl)
+    (reload)
+    (speak)
+    ;; remove possible artifacts of Figwheel compilation
+    (sift :include #{#"^devcards\/(out\/|main.js)"} :invert true)
+    (cljs :source-map true
+          :compiler-options {:devcards true
+                             :main 'om.devcards.core
+                             :parallel-build true}
+          :ids #{"devcards/main"})
+    (target)))
+
+(deftask testing []
+  (set-env! :source-paths #(conj % "src/test"))
+  identity)
+
+(ns-unmap 'boot.user 'test)
+
+(deftask test
+  [e exit?     bool  "Enable flag."]
+  (let [exit? (cond-> exit?
+                (nil? exit?) not)]
+    (comp
+      (testing)
+      (test-cljs
+        :js-env :node
+        :namespaces #{'om.next.tests}
+        :cljs-opts {:parallel-build true}
+        :exit? exit?))))
+
+(deftask auto-test []
+  (comp
+    (watch)
+    (speak)
+    (test :exit? false)))

--- a/pom.xml
+++ b/pom.xml
@@ -75,20 +75,9 @@
             <exclusions>
                 <exclusion>
                     <groupId>org.clojure</groupId>
-                    <artifactId>tools.reader</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.clojure</groupId>
                     <artifactId>data.json</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.clojure</groupId>
-            <artifactId>tools.reader</artifactId>
-            <version>1.0.0-beta1</version>
-            <classifier>aot</classifier>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.clojure</groupId>
@@ -100,7 +89,7 @@
         <dependency>
             <groupId>org.clojure</groupId>
             <artifactId>core.async</artifactId>
-            <version>0.2.374</version>
+            <version>0.2.385</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -112,7 +101,7 @@
         <dependency>
             <groupId>com.cognitect</groupId>
             <artifactId>transit-clj</artifactId>
-            <version>0.8.285</version>
+            <version>0.8.288</version>
         </dependency>
         <dependency>
             <groupId>com.cognitect</groupId>
@@ -132,7 +121,7 @@
         <dependency>
             <groupId>org.clojure</groupId>
             <artifactId>tools.nrepl</artifactId>
-            <version>0.2.11</version>
+            <version>0.2.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/project.clj
+++ b/project.clj
@@ -10,21 +10,22 @@
 
   :source-paths  ["src/main" "src/devcards" "src/test"]
 
-  :dependencies [[org.clojure/clojure "1.8.0" :scope "provided"]
-                 [org.clojure/clojurescript "1.8.51" :scope "provided"
-                  :exclusions [org.clojure/tools.reader org.clojure/data.json]]
-                 [org.clojure/tools.reader "1.0.0-beta1" :scope "provided"]
-                 [org.clojure/data.json "0.2.6" :scope "provided"]
+  :dependencies [[org.clojure/clojure "1.9.0-alpha10" :scope "provided"]
+                 [org.clojure/clojurescript "1.9.227" :scope "provided" :classifier "aot"
+                  :exclusions [org.clojure/clojure
+                               org.clojure/data.json]]
+                 [org.clojure/data.json "0.2.6" :scope "provided" :classifier "aot"]
                  [cljsjs/react "15.2.1-0"]
                  [cljsjs/react-dom "15.2.1-0"]
-                 [com.cognitect/transit-clj "0.8.285"]
+                 [com.cognitect/transit-clj "0.8.288"]
                  [com.cognitect/transit-cljs "0.8.239"]
 
-                 [org.clojure/core.async "0.2.374" :scope "test"
+                 [org.clojure/core.async "0.2.385" :scope "test"
                   :exclusions [org.clojure/tools.reader]]
-                 [figwheel-sidecar "0.5.2" :scope "test"
-                  :exclusions [org.clojure/clojurescript org.clojure/tools.reader]]
-                 [devcards "0.2.1-6" :scope "test"
+                 [figwheel-sidecar "0.5.6" :scope "test"
+                  :exclusions [org.clojure/clojurescript
+                               org.clojure/tools.reader]]
+                 [devcards "0.2.1-7" :scope "test"
                   :exclusions [org.clojure/clojurescript]]]
 
   :plugins [[lein-cljsbuild "1.1.2"]]

--- a/resources/public/devcards/main.cljs.edn
+++ b/resources/public/devcards/main.cljs.edn
@@ -1,0 +1,2 @@
+{:require [om.devcards.core]
+ :compiler-options {:asset-path "main.out"}}

--- a/src/devcards/om/devcards/core.cljs
+++ b/src/devcards/om/devcards/core.cljs
@@ -1,6 +1,6 @@
 (ns om.devcards.core
   (:require [cljs.test :refer-macros [is async]]
-            [devcards.core :refer-macros [defcard deftest dom-node]]
+            [devcards.core :refer-macros [defcard deftest dom-node start-devcard-ui!]]
             [cljs.pprint :as pprint]
             [om.devcards.utils :as utils]
             [om.devcards.tutorials]
@@ -11,6 +11,7 @@
             [om.dom :as dom]))
 
 (enable-console-print!)
+(start-devcard-ui!)
 
 (defui Hello
   Object
@@ -61,7 +62,7 @@
 ;; -----------------------------------------------------------------------------
 ;; Counters
 
-(defmulti counters-read (fn [_ k] k))
+(defmulti counters-read (fn [_ k _] k))
 
 (defmulti counters-mutate (fn [_ k _] k))
 
@@ -73,7 +74,7 @@
       {:remote true})))
 
 (defmethod counters-read :counters/list
-  [{:keys [state query]} _]
+  [{:keys [state query]} _ _]
   (let [st @state
         xf (map #(select-keys (get-in st %) query))]
     {:value (into [] xf (:counters/list st))}))


### PR DESCRIPTION
- Add a `build.boot` file along with a `boot.properties` and a
  `main.cljs.edn` for CLJS compilation
- Bump some deps in `pom.xml` and remove `tools.reader` from
  ClojureScript's exclusions, since it now provides 1.0.0-beta3
- Bring `project.clj` to parity with the dependencies in pom.xml