### PR TITLE
OM-766: Incremental rendering in reconcile! throws Index out of bounds

### DIFF
--- a/src/main/om/next.cljs
+++ b/src/main/om/next.cljs
@@ -1827,12 +1827,13 @@
                              (not= c root)
                              props-change?)
                     (let [update-path (path c)]
-                      (loop [p (parent c)]
-                        (when (some? p)
-                          (let [update-path' (subvec update-path (count (path p)))]
-                            (update-props! p (assoc-in (props p) update-path' next-raw-props))
-                            (merge-pending-props! p)
-                            (recur (parent p)))))))))))))))
+                      (when-not (nil? update-path)
+                        (loop [p (parent c)]
+                          (when (some? p)
+                            (let [update-path' (subvec update-path (count (path p)))]
+                              (update-props! p (assoc-in (props p) update-path' next-raw-props))
+                              (merge-pending-props! p)
+                              (recur (parent p))))))))))))))))
 
   (send! [this]
     (let [sends (:queued-sends @state)]


### PR DESCRIPTION
We need to check that the update-path is non-nil, because users might be passing props which don't have path-meta to e.g. components that don't have queries