### PR TITLE
OM-786: Be more permissive for static class methods

### DIFF
--- a/src/main/om/next.cljc
+++ b/src/main/om/next.cljc
@@ -313,9 +313,6 @@
            [other-protocols obj-dt] (split-with (complement '#{Object}) dt)
            class-methods (when-not (empty? (:protocols statics))
                            (->> (partition 2 (:protocols statics))
-                             (filter (fn [[p _]]
-                                       (some #{(clojure.core/name p)}
-                                         '#{"IQuery" "Ident" "IQueryParams"})))
                              (reduce
                                (fn [r [_ impl]]
                                  (assoc r (keyword (first impl))
@@ -408,14 +405,10 @@
             (fn [this# writer# opt#]
               (cljs.core/-write writer# ~(str rname)))))))))
 
-#?(:clj
-   (defmacro defui-clj [name & forms]
-     (defui*-clj name forms)))
-
 (defmacro defui [name & forms]
   (if (boolean (:ns &env))
     (defui* name forms &env)
-    `(defui-clj ~name ~@forms)))
+    #?(:clj (defui*-clj name forms))))
 
 (defmacro ui
   [& forms]

--- a/src/test/om/next/tests.cljc
+++ b/src/test/om/next/tests.cljc
@@ -270,6 +270,18 @@
       (is (= (om/full-query child)
             '[{[:users/by-id 2] [:foo]}])))))
 
+(defprotocol OM-786-Protocol
+  (some-func [this]))
+
+(defui OM-786-Component
+  static OM-786-Protocol
+  (some-func [this]
+    42))
+
+(deftest test-om-786
+  (is (= #?(:clj  ((-> OM-786-Component meta :some-func) OM-786-Component)
+            :cljs (some-func OM-786-Component)) 42)))
+
 ;; -----------------------------------------------------------------------------
 ;; Query Templating
 


### PR DESCRIPTION
This affects only the `:clj` branch which was not compliant with how we
allows static methods in ClojureScript.

Also simplify a bit the logic around `defui` for the `:clj` branch