### PR TITLE
OM-798: remove support for unsupported tags

### DIFF
--- a/src/main/om/dom.cljc
+++ b/src/main/om/dom.cljc
@@ -1,5 +1,5 @@
 (ns om.dom
-  (:refer-clojure :exclude [map meta time use])
+  (:refer-clojure :exclude [map meta time])
   #?(:clj
      (:require [clojure.string :as str]
                [om.next.protocols :as p]
@@ -134,8 +134,7 @@
     polygon
     radialGradient
     stop
-    tspan
-    use])
+    tspan])
 
 (defn ^:private gen-react-dom-inline-fn [tag]
   `(defmacro ~tag [opts# & children#]


### PR DESCRIPTION
as per the link below, `use` is not present in `React.DOM`. Use
`(js/React.createElement "use")` to create tags not existent in
`React.DOM`.

https://github.com/facebook/react/blob/c78464/src/isomorphic/classic/element/ReactDOMFactories.js
