### PR TITLE
Fix race condition between schedule-render! and send cb's reconcile! that preventing future reconciling

### DIFF
--- a/src/main/om/next.cljc
+++ b/src/main/om/next.cljc
@@ -2471,7 +2471,7 @@
           q (if-not (nil? remote)
               (get-in st [:remote-queue remote])
               (:queue st))]
-      (swap! state update-in [:queued] not)
+      (swap! state assoc :queued false)
       (if (not (nil? remote))
         (swap! state assoc-in [:remote-queue remote] [])
         (swap! state assoc :queue []))


### PR DESCRIPTION
Fixes GH-862.

Right now, [this block of code](https://github.com/omcljs/om/blob/master/src/main/om/next.cljc#L2535-L2539) can result in a race condition that can stop future reconciling from occuring:

```clojure
            ([resp query remote]
             (when-not (nil? remote)
               (p/queue! this (keys resp) remote))
             (merge! this resp query remote)
             (p/reconcile! this remote))))))))
```

In particular, `(merge! ...)` will cause a state change that can trigger a `(schedule-render! ...)`. In cases where the `requestAnimationFrame` immediately runs the scheduled reconcile, this [line](https://github.com/omcljs/om/blob/master/src/main/om/next.cljc#L2474) will set `:queued` to `false`:

```clojure
      (swap! state update-in [:queued] not)
```

In this scenario, the last`(p/reconcile! this remote)` in the code block above will run right after the reconcile triggered by `requestAnimationFrame`. This reconcile will also call the following line:

```clojure
      (swap! state update-in [:queued] not)
```

which will set `:queued` to `true`, without adding enqueueing anything to `:queue-remote` or `:queue`.

This puts our reconciler into a state in which subsequent calls to [`schedule-render!`](https://github.com/omcljs/om/blob/master/src/main/om/next.cljc#L1450-L1452) will think that there is already a render scheduled and won't queue a render and reconcile.

```clojure
   (defn schedule-render! [reconciler]
     (when (p/schedule-render! reconciler)
       (queue-render! #(p/reconcile! reconciler))))
```

where `p/schedule-render!` is defined as follows:

```clojure
  (schedule-render! [_]
    (if-not (:queued @state)
      (do
        (swap! state assoc :queued true)
        true)
      false))
```

This means that any reconciles that would result from a change in our reconciler `:state` won't trigger a reconcile. See [here](https://github.com/omcljs/om/blob/master/src/main/om/next.cljc#L2402-L2408):

```clojure
        (add-watch (:state config) (or target guid)
          (fn [_ _ _ _]
            (swap! state update-in [:t] inc)
            #?(:cljs
               (if-not (iquery? root-class)
                 (queue-render! parsef)
                 (schedule-render! this)))))
```