### PR TITLE
Fix OM 877 - Fix db->tree recursive edge case

### DIFF
--- a/src/main/om/next.cljc
+++ b/src/main/om/next.cljc
@@ -2107,6 +2107,9 @@
                            (if-not (nil? joins)
                              (let [join        (first joins)
                                    [key sel]   (util/join-entry join)
+                                   sel         (if (= key recurse-key)
+                                                 query
+                                                 sel)
                                    v           (get ident key)]
                                (recur (next joins)
                                  (assoc ret

--- a/src/test/om/next/next_test.clj
+++ b/src/test/om/next/next_test.clj
@@ -909,3 +909,16 @@
           (#'om/extract-static-methods '[Multi
                                          (method-a [this arg] :a)
                                          (method-a [this] :b)])))))
+
+(deftest test-om-877-recursive-edge-case
+  (let [query [{:tree [:id
+                       :value
+                       {:children '...}]}]
+        state {:tree {:id 0 :value 42
+                      :children [{:id 1 :value 43
+                                  :children [{:id 2 :value 99
+                                              :children []}]}
+                                 {:id 3 :value 101
+                                  :children []}]}}]
+    (is (= state
+           (om/db->tree query state state)))))


### PR DESCRIPTION
See GH-877:

In JVM clojure, the following will fail:

```clojure
(let [query [{:tree [:id
                         :value
                         {:children '...}]}]
          state {:tree {:id 0 :value 42
                        :children [{:id 1 :value 43
                                    :children [{:id 2 :value 99
                                                :children []}]}
                                   {:id 3 :value 101
                                    :children []}]}}]
      (is (= state
             (om/db->tree query state state))))
```

with exception

```
java.lang.IllegalArgumentException: Don't know how to create ISeq from: clojure.lang.Symbol
```