### PR TITLE
Use react-create-class since React.createClass is deprecated

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -12,6 +12,7 @@
                   :classifier "aot"]
                  [cljsjs/react                "15.5.4-0"]
                  [cljsjs/react-dom            "15.5.4-0"]
+                 [cljsjs/create-react-class   "15.6.0-0"]
                  [com.cognitect/transit-clj   "0.8.300"]
                  [com.cognitect/transit-cljs  "0.8.239"]
 

--- a/project.clj
+++ b/project.clj
@@ -17,6 +17,7 @@
                  [org.clojure/data.json "0.2.6" :scope "provided" :classifier "aot"]
                  [cljsjs/react "15.5.4-0"]
                  [cljsjs/react-dom "15.5.4-0"]
+                 [cljsjs/create-react-class "15.6.0-0"]
                  [com.cognitect/transit-clj "0.8.300"]
                  [com.cognitect/transit-cljs "0.8.239"]
 

--- a/src/main/om/core.cljs
+++ b/src/main/om/core.cljs
@@ -900,7 +900,7 @@
    (let [rdesc (or descriptor *descriptor* pure-descriptor)]
      (when (or (nil? (gobj/get f "om$descriptor"))
                (not (identical? rdesc (gobj/get f "om$tag"))))
-       (let [factory (js/React.createFactory (js/React.createClass rdesc))]
+       (let [factory (js/React.createFactory (dom/create-class rdesc))]
          (gobj/set f "om$descriptor" factory)
          (gobj/set f "om$tag" rdesc))))
    (gobj/get f "om$descriptor")))

--- a/src/main/om/dom.cljs
+++ b/src/main/om/dom.cljs
@@ -3,14 +3,21 @@
   (:require-macros [om.dom :as dom])
   (:require [cljsjs.react]
             [cljsjs.react.dom]
+            [cljsjs.create-react-class]
             [om.util :as util]
             [goog.object :as gobj]))
+
+(defonce create-class
+  (cond (exists? js/createReactClass) js/createReactClass
+        (exists? js/require) (or (js/require "create-react-class")
+                                 (throw (js/Error. "require('create-react-class') failed")))
+        :else (throw (js/Error. "js/createReactClass is missing"))))
 
 (dom/gen-react-dom-fns)
 
 (defn wrap-form-element [ctor display-name]
   (js/React.createFactory
-    (js/React.createClass
+    (create-class
       #js
       {:getDisplayName
        (fn [] display-name)


### PR DESCRIPTION
Closes #881 