### PR TITLE
Fix bind-query to work with MapEntry

### DIFF
--- a/src/main/om/next.cljc
+++ b/src/main/om/next.cljc
@@ -702,7 +702,10 @@
         tr (map #(bind-query % params))
         ret (cond
               (seq? query) (apply list (into [] tr query))
-              #?@(:clj [(instance? clojure.lang.IMapEntry query) (into [] tr query)])
+              ;; Note we use an empty vector rather than calling empty on
+              ;; query because MapEntries and PersistentVectors are captured by
+              ;; vector? but MapEntry does not empty to [].
+              (vector? query) (into [] tr query)
               (coll? query) (into (empty query) tr query)
               :else (replace-var query params))]
     (cond-> ret


### PR DESCRIPTION
This patch fixes om.next under recent versions of ClojureScript which use MapEntry rather than PersistentVector for map entries.

I've tested it under the 1.10.126 and 1.9.908 with the `boot test` suite and a om.next project.

The patch uses `vector?` rather than `map-entry?` which would have made the intentions clearer but is not available in older versions of CLJS where as this patch should be backwards compatible.