### PR TITLE
Update renamed clojurescript fn

### DIFF
--- a/src/main/om/next.cljc
+++ b/src/main/om/next.cljc
@@ -284,7 +284,7 @@
 
 #?(:clj
    (defn- proto-assign-impls [env resolve type-sym type [p sigs]]
-     (#'cljs.core/warn-and-update-protocol p type env)
+     (#'cljs.core/update-protocol-var p type env)
      (let [psym      (resolve p)
            pprefix   (#'cljs.core/protocol-prefix psym)
            skip-flag (set (-> type-sym meta :skip-protocol-flag))


### PR DESCRIPTION
A [change to cljs.core][1] renamed the `warn-and-update-protocol` fn, which om relies on via a macro.  The clojurescript commit simply changes the name to `update-protocol-var`, so this commit in om does the same.

@swannodette would appreciate your thoughts - this unblocks clojurescript upgrades on om.next projects, so I'd love to see it in!

[1]: https://github.com/clojure/clojurescript/commit/13fde33d737b0d47bdaaf102ed8e1c49342ade3c